### PR TITLE
Increase the limit of labels to load

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
         } elseif ($env:LABEL_PATTERN) {
           $labelRegex = "$env:LABEL_PATTERN"
           $labelSelector = "[.[] | select(.name | test(`"$labelRegex`"))]"
-          $labelsResult = gh label list --repo "$repoUrl" --json name --jq "$labelSelector"
+          $labelsResult = gh label list --repo "$repoUrl" --json name --jq "$labelSelector" --limit 100
           $labels = $labelsResult | ConvertFrom-Json
           Write-Output "::debug::$labels"
           if (-not $labels) {


### PR DESCRIPTION
The default label load was 30, and this meant most labels would not be loaded.

The new limit is now 100, so it should get them all. We will need to properly download them all, be that we can do later.